### PR TITLE
Add `remoteContracts` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ your own API key [here][55] and set it with the `coinmarketcap` option.
 | remoteContracts | _RemoteContract[]_               | `[]`                  | Contracts
 pre-deployed to a (forked) network the reporter should collect gas usage data for. (See [RemoteContract type][44])                                |
 
+[44]:
 [55]: https://coinmarketcap.com/api/pricing/
 
 
@@ -117,3 +118,4 @@ pre-deployed to a (forked) network the reporter should collect gas usage data fo
 Other useful documentation can be found at [eth-gas-reporter](https://github.com/cgewecke/eth-gas-reporter)
 
 [1]: https://github.com/cgewecke/buidler-gas-reporter/tree/buidler-final#installation
+

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This reporter comes with a [codechecks](http://codechecks.io) CI integration tha
 displays a pull request's gas consumption changes relative to its target branch in the Github UI.
 It's like coveralls for gas. The codechecks service is free for open source and maintained by MakerDao engineer [@krzkaczor](https://github.com/krzkaczor).
 
-Complete [set-up guide here](https://github.com/cgewecke/eth-gas-reporter/blob/master/docs/codechecks.md) (it's easy). 
+Complete [set-up guide here](https://github.com/cgewecke/eth-gas-reporter/blob/master/docs/codechecks.md) (it's easy).
 
 ![Screen Shot 2019-06-18 at 12 25 49 PM](https://user-images.githubusercontent.com/7332026/59713894-47298900-91c5-11e9-8083-233572787cfa.png)
 
@@ -106,6 +106,8 @@ your own API key [here][55] and set it with the `coinmarketcap` option.
 | showMethodSig     | _Boolean_              | false                       | Display complete method signatures. Useful when you have overloaded methods you can't tell apart.                                                                                                                                            |
 | maxMethodDiff     | _Number_               | undefined                   | Codechecks failure threshold, triggered when the % diff for any method is greater than `number` (integer)                                                                                                                                    |
 | maxDeploymentDiff | _Number_               | undefined                   | Codechecks failure threshold, triggered when the % diff for any deployment is greater than `number` (integer)                                                                                                                                |
+| remoteContracts | _RemoteContract[]_               | `[]`                  | Contracts
+pre-deployed to a (forked) network the reporter should collect gas usage data for. (See [RemoteContract type][44])                                |
 
 [55]: https://coinmarketcap.com/api/pricing/
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-gas-reporter",
-  "version": "1.0.2-rc.0",
+  "version": "1.0.2-rc.1",
   "description": "Hardhat plugin for eth-gas-reporter, a mocha reporter for Ethereum test suites",
   "repository": "github:cgewecke/hardhat-gas-reporter",
   "author": "cgewecke",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "hardhat": "^2.0.2"
   },
   "dependencies": {
-    "eth-gas-reporter": "^0.2.19"
+    "eth-gas-reporter": "https://github.com/cgewecke/eth-gas-reporter.git#bcd8bd32d719cb8969396a236e8fb041fbd9c279",
+    "sha1": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-gas-reporter",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.0",
   "description": "Hardhat plugin for eth-gas-reporter, a mocha reporter for Ethereum test suites",
   "repository": "github:cgewecke/hardhat-gas-reporter",
   "author": "cgewecke",

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,10 +15,19 @@ export interface EthGasReporterConfig {
   maxMethodDiff?: number;
   maxDeploymentDiff?: number;
   enabled?: boolean;
+  remoteContracts?: RemoteContract[]
 
   // Hardhat internals set for eth-gas-reporter
   metadata?: any;
   getContracts?: any;
   url?: string;
   fast?: boolean;
+}
+
+export interface RemoteContract {
+  abi: any;
+  address: string;
+  name: string;
+  bytecode?: string;
+  deployedBytecode?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,5 +29,6 @@ export interface RemoteContract {
   address: string;
   name: string;
   bytecode?: string;
+  bytecodeHash?: string;
   deployedBytecode?: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1836,10 +1836,9 @@ eth-ens-namehash@2.0.8, eth-ens-namehash@^2.0.0:
     idna-uts46-hx "^2.3.1"
     js-sha3 "^0.5.7"
 
-eth-gas-reporter@^0.2.19:
+"eth-gas-reporter@https://github.com/cgewecke/eth-gas-reporter.git#bcd8bd32d719cb8969396a236e8fb041fbd9c279":
   version "0.2.19"
-  resolved "https://registry.yarnpkg.com/eth-gas-reporter/-/eth-gas-reporter-0.2.19.tgz#57ce74e0617d021d04fd1789a4232837d0f41918"
-  integrity sha512-yQmbAa6O9/Yl/syNml2A0R+ZLQnJ9m9jogFXHzjMWVBMUVnAcEskOVyxaMYddkclZdYIMxE99tQy830C2jLsAQ==
+  resolved "https://github.com/cgewecke/eth-gas-reporter.git#bcd8bd32d719cb8969396a236e8fb041fbd9c279"
   dependencies:
     "@ethersproject/abi" "^5.0.0-beta.146"
     "@solidity-parser/parser" "^0.8.0"


### PR DESCRIPTION
This option accepts an array of "remote contract" objects whose definition is 
```ts
{
  abi: any;
  address: string;
  name: string;
}
``` 
The option allows you to collect data for contracts pre-deployed to a parent chain when using forked providers. 

**TODO**
- [ ] Reset package version
- [ ] Set readme link for RemoteContracts  type
- [ ] Publish eth-gas-reporter and update dep here