### PR TITLE
Add types for multi chain gas prices

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 export interface EthGasReporterConfig {
   currency?: string;
+  token?: string;
   gasPrice?: number;
+  gasPriceApi?: string;
   coinmarketcap?: string;
   outputFile?: string;
   noColors?: boolean;


### PR DESCRIPTION
When I tried to set up calculating prices in MATIC, I saw that the types for the new fields token and gasPriceApi were not added to the EthGasReporterConfig and I couldn't run tests because of the type warning on 1.0.5 of hardhat-gas-reporter.