### PR TITLE
support `ethPrice` config

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface EthGasReporterConfig {
   currency?: string;
   token?: string;
+  ethPrice?: number;
   gasPrice?: number;
   gasPriceApi?: string;
   coinmarketcap?: string;


### PR DESCRIPTION
For some reasons `eth-gas-reporter` config option `ethPrice` (see: https://github.com/cgewecke/eth-gas-reporter/blob/deadc079f1920590ea362fdd6e0e008e70e4f95f/lib/config.js#L17 ) isn't currently supported. 

This should also solve: https://github.com/cgewecke/hardhat-gas-reporter/issues/82 - see: https://github.com/cgewecke/eth-gas-reporter/blob/deadc079f1920590ea362fdd6e0e008e70e4f95f/lib/utils.js#L170-L178