### PR TITLE
Import libraries when they are needed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import fs from "fs"
 import path from "path"
-import arrayUniq from "array-uniq";
 import { TASK_TEST_RUN_MOCHA_TESTS } from "hardhat/builtin-tasks/task-names";
 import { task, subtask } from "hardhat/config";
 import { HARDHAT_NETWORK_NAME, HardhatPluginError } from "hardhat/plugins";
@@ -259,7 +258,8 @@ task(TASK_GAS_REPORTER_MERGE)
 
 		// Parse input files and calculate glob patterns
     const { globSync } = await import("hardhat/internal/util/glob");
-		const inputFiles = arrayUniq<string>(taskArguments.input.map(globSync).flat())
+    const arrayUniq = require("array-uniq");
+		const inputFiles = arrayUniq(taskArguments.input.map(globSync).flat())
       .map(inputFile => path.resolve(inputFile));
 
 		if (inputFiles.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import arrayUniq from "array-uniq";
 import { TASK_TEST_RUN_MOCHA_TESTS } from "hardhat/builtin-tasks/task-names";
 import { task, subtask } from "hardhat/config";
 import { HARDHAT_NETWORK_NAME, HardhatPluginError } from "hardhat/plugins";
-import { globSync } from "hardhat/internal/util/glob";
 
 import type { EGRAsyncApiProvider as EGRAsyncApiProviderT } from "./providers";
 
@@ -259,6 +258,7 @@ task(TASK_GAS_REPORTER_MERGE)
 		const output = path.resolve(process.cwd(), taskArguments.output);
 
 		// Parse input files and calculate glob patterns
+    const { globSync } = await import("hardhat/internal/util/glob");
 		const inputFiles = arrayUniq<string>(taskArguments.input.map(globSync).flat())
       .map(inputFile => path.resolve(inputFile));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,6 @@ import { TASK_TEST_RUN_MOCHA_TESTS } from "hardhat/builtin-tasks/task-names";
 import { task, subtask } from "hardhat/config";
 import { HARDHAT_NETWORK_NAME, HardhatPluginError } from "hardhat/plugins";
 import { globSync } from "hardhat/internal/util/glob";
-import {
-  BackwardsCompatibilityProviderAdapter
-} from "hardhat/internal/core/providers/backwards-compatibility"
 
 
 import {
@@ -203,6 +200,11 @@ subtask(TASK_TEST_RUN_MOCHA_TESTS).setAction(
       mochaConfig.reporterOptions = options;
 
       if (hre.network.name === HARDHAT_NETWORK_NAME || options.fast){
+
+        const {
+          BackwardsCompatibilityProviderAdapter
+        } = await import("hardhat/internal/core/providers/backwards-compatibility")
+
         const wrappedDataProvider= new EGRDataCollectionProvider(hre.network.provider,mochaConfig);
         hre.network.provider = new BackwardsCompatibilityProviderAdapter(wrappedDataProvider);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,6 @@ import { EthGasReporterConfig, EthGasReporterOutput, RemoteContract } from "./ty
 import { TASK_GAS_REPORTER_MERGE, TASK_GAS_REPORTER_MERGE_REPORTS } from "./task-names";
 import { mergeReports } from "./merge-reports";
 
-const { parseSoliditySources, setGasAndPriceRates } = require('eth-gas-reporter/lib/utils');
-const InternalReporterConfig  = require('eth-gas-reporter/lib/config');
-
 let mochaConfig;
 let resolvedQualifiedNames: string[]
 let resolvedRemoteContracts: RemoteContract[] = [];
@@ -184,6 +181,10 @@ subtask(TASK_TEST_RUN_MOCHA_TESTS).setAction(
         );
         return result;
       }
+
+
+      const { parseSoliditySources, setGasAndPriceRates } = require('eth-gas-reporter/lib/utils');
+      const InternalReporterConfig  = require('eth-gas-reporter/lib/config');
 
       // Fetch data from gas and coin price providers
       options = new InternalReporterConfig(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,7 @@ import { task, subtask } from "hardhat/config";
 import { HARDHAT_NETWORK_NAME, HardhatPluginError } from "hardhat/plugins";
 import { globSync } from "hardhat/internal/util/glob";
 
-
-import {
-  EGRDataCollectionProvider,
-  EGRAsyncApiProvider
-} from "./providers";
+import type { EGRAsyncApiProvider as EGRAsyncApiProviderT } from "./providers";
 
 import {
   HardhatArguments,
@@ -152,7 +148,7 @@ function getOptions(hre: HardhatRuntimeEnvironment): any {
  * @return {Promise<RemoteContract[]>}
  */
 async function getResolvedRemoteContracts(
-  provider: EGRAsyncApiProvider,
+  provider: EGRAsyncApiProviderT,
   remoteContracts: RemoteContract[] = []
 ) : Promise <RemoteContract[]> {
   for (const contract of remoteContracts){
@@ -204,6 +200,11 @@ subtask(TASK_TEST_RUN_MOCHA_TESTS).setAction(
         const {
           BackwardsCompatibilityProviderAdapter
         } = await import("hardhat/internal/core/providers/backwards-compatibility")
+
+        const {
+          EGRDataCollectionProvider,
+          EGRAsyncApiProvider
+        } = await import("./providers");
 
         const wrappedDataProvider= new EGRDataCollectionProvider(hre.network.provider,mochaConfig);
         hre.network.provider = new BackwardsCompatibilityProviderAdapter(wrappedDataProvider);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import fs from "fs"
 import path from "path"
-import sha1 from "sha1"
 import arrayUniq from "array-uniq";
 import { TASK_TEST_RUN_MOCHA_TESTS } from "hardhat/builtin-tasks/task-names";
 import { task, subtask } from "hardhat/config";
@@ -150,6 +149,7 @@ async function getResolvedRemoteContracts(
   provider: EGRAsyncApiProviderT,
   remoteContracts: RemoteContract[] = []
 ) : Promise <RemoteContract[]> {
+  const { defualt : sha1 } = await import("sha1");
   for (const contract of remoteContracts){
     let code;
     try {


### PR DESCRIPTION
Hey Chris!

This is a quick PR to optimize this plugin. The change introduced here is that it now imports external libraries right before they are needed. This means that they are not loaded during Hardhat initialization, so that Hardhat loads faster. You can appreciate the difference if you run a `npx hardhat --help` in a project using this version of the plugin and `latest`.

The difference is not huge, but it compounds with other plugins, so I'm doing this for every plugin included in the hardhat toolbox. I'll also send a similar PR to `solidity-coverage`.

~A test is failing, but it was also failing on `master`. I can fix it, but I may require some guidance.~ It passes on the CI