### PR TITLE
fix: rstTitle type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface EthGasReporterConfig {
   noColors?: boolean;
   onlyCalledMethods?: boolean;
   rst?: boolean;
-  rstTitle?: boolean;
+  rstTitle?: string;
   showTimeSpent?: boolean;
   excludeContracts?: string[];
   src?: string;


### PR DESCRIPTION
Not sure if I'm missing something but the type for `rstTitle` should be `string`. Was confused by the difference in documentation and implemented types, after some digging figured this was an error.