### PR TITLE
Add viem support & tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test/projects/viem/artifacts/**

--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,9 @@ test/projects/forked/artifacts
 test/projects/forked/cache
 test/projects/forked/gasReporterOutput.json
 
+test/projects/viem/artifacts
+test/projects/viem/cache
+test/projects/viem/gasReporterOutput.json
+
 dist/
 

--- a/package.json
+++ b/package.json
@@ -32,11 +32,15 @@
     "README.md"
   ],
   "devDependencies": {
+    "@nomicfoundation/hardhat-network-helpers": "1.0.10",
+    "@nomicfoundation/hardhat-toolbox-viem": "2.0.0",
+    "@nomicfoundation/hardhat-viem": "1.0.2",
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-truffle5": "^2.0.7",
     "@nomiclabs/hardhat-waffle": "^2.0.6",
     "@nomiclabs/hardhat-web3": "^2.0.0",
     "@types/chai": "^4.2.14",
+    "@types/chai-as-promised": "7.1.8",
     "@types/fs-extra": "^5.0.4",
     "@types/lodash": "^4.14.202",
     "@types/mocha": "7",
@@ -45,6 +49,7 @@
     "@typescript-eslint/eslint-plugin": "5.61.0",
     "@typescript-eslint/parser": "5.61.0",
     "chai": "^4.2.0",
+    "chai-as-promised": "7.1.1",
     "dotenv": "^6.2.0",
     "eslint": "8.44.0",
     "eslint-plugin-import": "2.27.5",
@@ -55,7 +60,8 @@
     "prettier": "2.4.1",
     "source-map-support": "^0.5.12",
     "ts-node": "^8.1.0",
-    "typescript": "4.7.4",
+    "typescript": "~5.0.4",
+    "viem": "1.18.0",
     "web3": "^1.3.0"
   },
   "peerDependencies": {

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -32,6 +32,7 @@ npx mocha test/integration/default.ts --timeout 100000 --exit
 npx mocha test/integration/options.a.ts --timeout 100000 --exit
 npx mocha test/integration/options.b.ts --timeout 100000 --exit
 npx mocha test/integration/forked.ts --timeout 100000 --exit
+npx mocha test/integration/viem.ts --timeout 100000 --exit
 
 # Temporarily skipping waffle test - simple txs error with internal ethers error:
 # `this.provider.getFeeData is not a function`

--- a/src/tasks/gasReporter.ts
+++ b/src/tasks/gasReporter.ts
@@ -39,6 +39,7 @@ subtask(TASK_GAS_REPORTER_START).setAction(
 
       hre.__hhgrec.collector = new Collector(options, hre.network.provider);
       hre.__hhgrec.collector.data.initialize(options, hre.network.provider, contracts);
+      hre.__hhgrec.usingViem = (hre as any).viem !== undefined;
 
       await initGasReporterProvider(hre.network.provider, hre.__hhgrec);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface GasReporterOptions {
 export interface GasReporterExecutionContext {
   collector?: Collector,
   task?: string,
+  usingViem?: boolean,
   blockGasLimit?: number;
   methodsTotalGas?: number,
   methodsTotalCost?: string,

--- a/test/integration/viem.ts
+++ b/test/integration/viem.ts
@@ -1,0 +1,52 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { assert } from "chai";
+import { TASK_TEST } from "hardhat/builtin-tasks/task-names";
+import path from "path";
+
+import { Deployment, GasReporterOutput, MethodData } from "../types";
+
+import { useEnvironment, findMethod, findDeployment } from "../helpers";
+
+describe("Viem", function () {
+  let output: GasReporterOutput;
+  let methods: MethodData;
+  let deployments: Deployment[];
+
+  const projectPath = path.resolve(
+    __dirname,
+    "../projects/viem"
+  );
+
+  const outputPath = path.resolve(
+    __dirname,
+    "../projects/viem/gasReporterOutput.json"
+  );
+
+  const network = undefined;
+  const configPath = "./hardhat.config.ts";
+
+  useEnvironment(projectPath, network, configPath);
+
+  before(async function(){
+    await this.env.run(TASK_TEST, { testFiles: [] });
+    output = require(outputPath);
+    methods = output.data!.methods;
+    deployments = output.data!.deployments;
+  })
+
+  it ("should record transactions made with the publicClient", function(){
+    const method = findMethod(methods, "Greeter", "setGreeting");
+    assert.equal(method?.numberOfCalls, 1);
+  });
+
+  it ("should record transactions made with a walletClient", function(){
+    const method = findMethod(methods, "Greeter", "asOther");
+    assert.equal(method?.numberOfCalls, 1);
+  });
+
+  it ("should record deployments", function(){
+    const deployment = findDeployment(deployments, "Greeter");
+    assert.isNotNull(deployment);
+    assert(deployment!.gasData.length > 0);
+  });
+});

--- a/test/projects/viem/contracts/Greeter.sol
+++ b/test/projects/viem/contracts/Greeter.sol
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: MIT */
+pragma solidity >=0.8.0 <0.9.0;
+
+contract Greeter {
+    string public greeting;
+
+    constructor(string memory _greeting) {
+        greeting = _greeting;
+    }
+
+    function greet() public view returns (string memory) {
+        return greeting;
+    }
+
+    function setGreeting(string memory _greeting) public {
+        greeting = _greeting;
+    }
+
+    function asOther() public {}
+
+    function throwAnError(string memory message) public {
+        greeting = "goodbye";
+        require(false, message);
+    }
+}

--- a/test/projects/viem/hardhat.config.ts
+++ b/test/projects/viem/hardhat.config.ts
@@ -1,0 +1,16 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import "@nomicfoundation/hardhat-viem";
+import { HardhatUserConfig } from "hardhat/types";
+
+// We load the plugin here (should work even if viem is first)
+import "../../../src/index";
+
+const config: HardhatUserConfig = {
+  solidity: "0.8.19",
+  mocha: {
+    reporter: "dot"
+  }
+};
+
+// eslint-disable-next-line import/no-default-export
+export default config;

--- a/test/projects/viem/test/greeter.ts
+++ b/test/projects/viem/test/greeter.ts
@@ -1,0 +1,79 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { assert, expect, use } from "chai";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import chaiAsPromised  from "chai-as-promised";
+
+import { viem } from "hardhat";
+
+use(chaiAsPromised);
+
+describe("Greeter contract", function() {
+  async function deployGreeterFixture() {
+    const publicClient = await viem.getPublicClient();
+    const [owner, other] = await viem.getWalletClients();
+
+    const deployGreeter = (args: [_greeting: string]) => viem.deployContract("Greeter", args);
+
+    const greeter = await deployGreeter(["Hi"]);
+
+    const greeterAsOther = await viem.getContractAt(
+      "Greeter",
+      greeter.address,
+      { walletClient: other }
+    );
+
+    return {
+      publicClient,
+      owner,
+      other,
+      deployGreeter,
+      greeter,
+      greeterAsOther,
+    }
+  }
+
+  it("Should shoud be deployable with different greetings", async function() {
+    const {
+      greeter,
+      deployGreeter,
+    } = await loadFixture(deployGreeterFixture);
+    assert.equal(await greeter.read.greeting(), "Hi");
+    const greeter2 = await deployGreeter(["Hola"]);
+    assert.equal(await greeter2.read.greeting(), "Hola");
+  });
+
+  it("Should return the greeting when greet is called", async function() {
+    const {
+      greeter,
+    } = await loadFixture(deployGreeterFixture);
+    assert.equal(await greeter.read.greet(), "Hi");
+  });
+
+  it("Should set a greeting", async function(){
+    const {
+      greeter,
+    } = await loadFixture(deployGreeterFixture);
+    await greeter.write.setGreeting(['ciao']);
+    assert.equal(await greeter.read.greet(), "ciao");
+  })
+
+  // NOTE: This test is to check whether gas reporter can catch calls from viem using
+  // other accounts. Expected to see an entry in the method data for `asOther`
+  it("Should call as other", async function(){
+    const {
+      greeterAsOther,
+    } = await loadFixture(deployGreeterFixture);
+    await greeterAsOther.write.asOther();
+  })
+
+  it("should revert with a message", async function(){
+    const {
+      greeterAsOther,
+    } = await loadFixture(deployGreeterFixture);
+    await expect(
+      greeterAsOther.write.throwAnError(['throwing...'])
+    ).to.eventually.be.rejectedWith('throwing...');
+  })
+});

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -12,9 +12,8 @@
     "skipLibCheck": true
   },
   // "files": [], // Any hardhat plugin's main .d.ts has to be added here
-  "exclude": ["dist", "node_modules"],
+  "exclude": ["dist", "node_modules", "./test"],
   "include": [
-    "./test",
     "./src"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,10 @@
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
 
+"@adraffy/ens-normalize@1.9.4":
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.9.4.tgz#aae21cb858bbb0411949d5b7b3051f4209043f62"
+
 "@chainsafe/as-sha256@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz#3639df0e1435cab03f4d9870cc3ac079e57a6fc9"
@@ -1324,6 +1328,12 @@
     tweetnacl "^1.0.3"
     tweetnacl-util "^0.15.1"
 
+"@noble/curves@1.2.0", "@noble/curves@~1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
+  dependencies:
+    "@noble/hashes" "1.3.2"
+
 "@noble/curves@1.3.0", "@noble/curves@~1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.3.0.tgz#01be46da4fd195822dab821e72f71bf4aeec635e"
@@ -1334,7 +1344,11 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.0.0.tgz#d5e38bfbdaba174805a4e649f13be9a9ed3351ae"
 
-"@noble/hashes@1.3.3", "@noble/hashes@~1.3.2":
+"@noble/hashes@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
+
+"@noble/hashes@1.3.3", "@noble/hashes@~1.3.0", "@noble/hashes@~1.3.2":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
 
@@ -1483,6 +1497,25 @@
     mcl-wasm "^0.7.1"
     rustbn.js "~0.2.0"
 
+"@nomicfoundation/hardhat-network-helpers@1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.10.tgz#c61042ceb104fdd6c10017859fdef6529c1d6585"
+  dependencies:
+    ethereumjs-util "^7.1.4"
+
+"@nomicfoundation/hardhat-toolbox-viem@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-toolbox-viem/-/hardhat-toolbox-viem-2.0.0.tgz#950cae5de583090147c0f7fd164d2d17cb28902f"
+  dependencies:
+    chai-as-promised "^7.1.1"
+
+"@nomicfoundation/hardhat-viem@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-viem/-/hardhat-viem-1.0.2.tgz#1b0478f2bf87b4fde2f0cb32f84b4cedd03cf263"
+  dependencies:
+    abitype "^0.9.8"
+    lodash.memoize "^4.1.2"
+
 "@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.1.tgz#4c858096b1c17fe58a474fe81b46815f93645c15"
@@ -1613,7 +1646,7 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.0.0.tgz#109fb595021de285f05a7db6806f2f48296fcee7"
 
-"@scure/base@~1.1.4":
+"@scure/base@~1.1.0", "@scure/base@~1.1.2", "@scure/base@~1.1.4":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.5.tgz#1d85d17269fe97694b9c592552dd9e5e33552157"
 
@@ -1624,6 +1657,14 @@
     "@noble/hashes" "~1.0.0"
     "@noble/secp256k1" "~1.5.2"
     "@scure/base" "~1.0.0"
+
+"@scure/bip32@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.3.2.tgz#90e78c027d5e30f0b22c1f8d50ff12f3fb7559f8"
+  dependencies:
+    "@noble/curves" "~1.2.0"
+    "@noble/hashes" "~1.3.2"
+    "@scure/base" "~1.1.2"
 
 "@scure/bip32@1.3.3":
   version "1.3.3"
@@ -1639,6 +1680,13 @@
   dependencies:
     "@noble/hashes" "~1.0.0"
     "@scure/base" "~1.0.0"
+
+"@scure/bip39@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.2.1.tgz#5cee8978656b272a917b7871c981e0541ad6ac2a"
+  dependencies:
+    "@noble/hashes" "~1.3.0"
+    "@scure/base" "~1.1.0"
 
 "@scure/bip39@1.2.2":
   version "1.2.2"
@@ -1810,6 +1858,16 @@
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
   dependencies:
     "@types/node" "*"
+
+"@types/chai-as-promised@7.1.8":
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz#f2b3d82d53c59626b5d6bbc087667ccb4b677fe9"
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*":
+  version "4.3.11"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.11.tgz#e95050bf79a932cb7305dd130254ccdf9bde671c"
 
 "@types/chai@^4.2.0", "@types/chai@^4.2.14":
   version "4.2.14"
@@ -1986,6 +2044,14 @@
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+
+abitype@0.9.8:
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.9.8.tgz#1f120b6b717459deafd213dfbf3a3dd1bf10ae8c"
+
+abitype@^0.9.8:
+  version "0.9.10"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.9.10.tgz#fa6fa30a6465da98736f98b6c601a02ed49f6eec"
 
 abstract-level@^1.0.0, abstract-level@^1.0.2, abstract-level@^1.0.3:
   version "1.0.3"
@@ -3201,6 +3267,12 @@ caseless@~0.12.0:
 catering@^2.1.0, catering@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/catering/-/catering-2.1.1.tgz#66acba06ed5ee28d5286133982a927de9a04b510"
+
+chai-as-promised@7.1.1, chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  dependencies:
+    check-error "^1.0.2"
 
 chai@^4.2.0:
   version "4.2.0"
@@ -6148,6 +6220,10 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
+isows@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.3.tgz#93c1cf0575daf56e7120bab5c8c448b0809d0d74"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -6546,6 +6622,10 @@ lodash.clonedeep@^4.5.0:
 lodash.escaperegexp@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
+
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -8873,13 +8953,13 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-
 typescript@^4.3.4:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+
+typescript@~5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"
@@ -9056,6 +9136,19 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+viem@1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-1.18.0.tgz#26566664d70ab0402f163547c1a27f83daf77d06"
+  dependencies:
+    "@adraffy/ens-normalize" "1.9.4"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@scure/bip32" "1.3.2"
+    "@scure/bip39" "1.2.1"
+    abitype "0.9.8"
+    isows "1.0.3"
+    ws "8.13.0"
 
 web3-bzz@1.2.11:
   version "1.2.11"
@@ -9845,6 +9938,10 @@ ws@7.2.3:
 ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+
+ws@8.13.0:
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
 
 ws@^3.0.0:
   version "3.3.3"


### PR DESCRIPTION
#170 

Ports #167, #157 to beta.

+ Adds recording for `eth_sendTransaction` if `viem` is exposed on the environment. 
  + if users mix viem with hardhat-ethers, the ethers call counts will be doubled
+ Adds tests for transactions executed with public and wallet clients. 
+ Issues highlighted in #157 about import order and wallet client txs missing are resolved by using `extendProvider` in the beta branch

Closes #167