### PR TITLE
Add `forceTerminalOutputFormat` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint": "eslint 'src/**/*.ts' 'test/**/*.ts' -c ./eslintrc.js",
     "test": "scripts/run-tests.sh",
     "test:integration": "mocha test/integration/*.ts --timeout 100000 --exit",
-    "test:unit": "mocha test/unit/*.ts",
+    "test:unit": "mocha test/unit/*.ts --timeout 10000",
     "prepublishOnly": "tsc --project tsconfig.prod.json",
     "build": "tsc --project tsconfig.prod.json",
     "buidl": "tsc",

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -20,7 +20,7 @@ start_hardhat_node() {
 ########
 # Units
 ########
-npx mocha test/unit/*.ts
+npx mocha test/unit/*.ts --timeout 10000
 
 ########
 # Tasks

--- a/src/lib/render/index.ts
+++ b/src/lib/render/index.ts
@@ -58,8 +58,14 @@ export function render(hre: HardhatRuntimeEnvironment, data: GasData, options: G
     if (options.forceTerminalOutput){
       const originalOutputFile = options.outputFile;
       const originalNoColors = options.noColors;
+      const originalReportFormat = options.reportFormat;
+
       options.outputFile = undefined;
       options.noColors = false;
+
+      options.reportFormat = (options.forceTerminalOutputFormat)
+        ? options.forceTerminalOutputFormat
+        : options.reportFormat;
 
       table = getTableForFormat(hre, data, options);
       console.log(table);
@@ -67,6 +73,7 @@ export function render(hre: HardhatRuntimeEnvironment, data: GasData, options: G
       // Reset the options, since they might be read in JSON below here
       options.outputFile = originalOutputFile;
       options.noColors = originalNoColors;
+      options.reportFormat = originalReportFormat;
     }
   } else {
     console.log(table);

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,9 @@ export interface GasReporterOptions {
   /** @property Write to terminal even when saving output to file */
   forceTerminalOutput?: boolean;
 
+  /** @property Table format to output forced terminal output in */
+  forceTerminalOutputFormat?: 'legacy' | 'terminal' | 'markdown';
+
   /** @property Gwei price per gas unit (eg: 20) */
   gasPrice?: number;
 

--- a/test/integration/options.b.ts
+++ b/test/integration/options.b.ts
@@ -40,6 +40,9 @@ describe("Options B", function () {
     assert.equal(options.token, "ETC");
     assert.equal(options.tokenPrice, "200.00");
     assert.equal(options.gasPrice, 40);
+    assert.equal(options.forceTerminalOutput, true);
+    assert.equal(options.forceTerminalOutputFormat, 'legacy');
+    assert.equal(options.reportFormat, 'terminal');
   });
 
   it("wrote table to file", function () {

--- a/test/projects/options/hardhat.options.b.config.ts
+++ b/test/projects/options/hardhat.options.b.config.ts
@@ -2,6 +2,7 @@
  * TESTS:
  * + user-configured token and gasPrice
  * + write-to-custom-file-name (JSON & txt)
+ * + force terminal output w/ custom output
  * + show uncalled methods
  */
 
@@ -35,7 +36,8 @@ const config: HardhatUserConfig = {
     showUncalledMethods: true,
     outputFile: "./testGasReport.txt",
     outputJSONFile: "./gas.json",
-    forceTerminalOutput: true
+    forceTerminalOutput: true,
+    forceTerminalOutputFormat: 'legacy'
   }
 };
 


### PR DESCRIPTION
#170 

Allow user to have different formats for the report they write to file vs. the render on terminal.