### PR TITLE
Add OZ Upgrades system resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",
+    "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/units": "^5.7.0",
     "array-uniq": "1.0.3",
     "axios": "^1.6.7",

--- a/src/lib/collector.ts
+++ b/src/lib/collector.ts
@@ -1,5 +1,5 @@
 import type { RpcReceiptOutput } from "hardhat/internal/hardhat-network/provider/output"
-import { EthereumProvider } from "hardhat/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { GasReporterOptions, JsonRpcTx } from "../types"
 import { getCalldataGasForNetwork, hexToDecimal } from "../utils/gas";
 import { getMethodID } from "../utils/sources";
@@ -15,10 +15,10 @@ export class Collector {
   public options: GasReporterOptions;
   public resolver: Resolver;
 
-  constructor(options: GasReporterOptions, provider: EthereumProvider) {
+  constructor(hre: HardhatRuntimeEnvironment, options: GasReporterOptions) {
     this.data = new GasData();
     this.options = options;
-    this.resolver = new Resolver(options, provider, this.data);
+    this.resolver = new Resolver(hre, options, this.data);
   }
 
   /**

--- a/src/lib/collector.ts
+++ b/src/lib/collector.ts
@@ -5,7 +5,7 @@ import { getCalldataGasForNetwork, hexToDecimal } from "../utils/gas";
 import { getMethodID } from "../utils/sources";
 import { GasData } from "./gasData";
 
-import { ProxyResolver } from "./proxyResolver";
+import { Resolver } from "./resolvers/index";
 
 /**
  * Collects gas usage data, associating it with the relevant contracts, methods.
@@ -13,12 +13,12 @@ import { ProxyResolver } from "./proxyResolver";
 export class Collector {
   public data: GasData;
   public options: GasReporterOptions;
-  public resolver: ProxyResolver;
+  public resolver: Resolver;
 
   constructor(options: GasReporterOptions, provider: EthereumProvider) {
     this.data = new GasData();
     this.options = options;
-    this.resolver = new ProxyResolver(options, provider, this.data);
+    this.resolver = new Resolver(options, provider, this.data);
   }
 
   /**
@@ -66,8 +66,7 @@ export class Collector {
 
     // Case: proxied call
     if (this._isProxied(contractName, tx.input!)) {
-      contractName = this.resolver.resolveByProxy(tx);
-
+      contractName = await this.resolver.resolveByProxy(tx);
       // Case: hidden contract factory deployment
     } else if (contractName === null) {
       contractName = await this.resolver.resolveByDeployedBytecode(

--- a/src/lib/resolvers/etherrouter.ts
+++ b/src/lib/resolvers/etherrouter.ts
@@ -1,0 +1,73 @@
+import { Interface } from "@ethersproject/abi";
+import { hexStripZeros } from "@ethersproject/bytes";
+import { JsonRpcTx } from "../../types";
+import { Resolver } from "./index";
+import { HardhatEthersProvider } from "@nomicfoundation/hardhat-ethers/internal/hardhat-ethers-provider";
+/**
+ * Example of a method that resolves the contract names of method calls routed through
+ * a simple proxy (EtherRouter-style) contract. At runtime, the function below will be bound to
+ * the `this` property of plugin's Resolver class and inherit its resources which include:
+ *
+ * > helpers to match methods to contracts (e.g all public methods on the Resolver & GasData classes)
+ * > an EIP1193 provider to make calls to the client.
+ *
+ * The method receives a JSONRPC formatted transaction object representing a tx
+ * the reporter could not deterministically associate with any contract. It relies on your
+ * knowledge of a proxy contract's API to derive the correct contract name.
+ *
+ * Returns contract name matching the resolved address.
+ * @param  {Object} transaction JSONRPC formatted transaction
+ * @return {String}             contract name
+ */
+export async function customResolver(this: Resolver, transaction: JsonRpcTx) {
+  let contractAddress;
+  let contractName;
+
+  try {
+    const ABI = ["function resolver()", "function lookup(bytes4 sig)"];
+    const iface = new Interface(ABI);
+
+    // The tx passed to this method had input data which didn't map to any methods on
+    // the contract it was sent to. It's possible the tx's `to` address points to
+    // a router contract which is designed to forward calls so we grab the
+    // method signature and ask the router if it knows who the intended recipient is.
+    const signature = transaction.input.slice(0, 10);
+
+    // EtherRouter has a public state variable called `resolver()` which stores the
+    // address of a contract which maps method signatures to their parent contracts.
+    // Note: Provider type is a generic EIP1193 provider, so you may need to cast to
+    // the type appropriate for your case.
+    const resolverAddress = await this.provider.send("eth_call", [{
+        to: transaction.to!,
+        data: iface.encodeFunctionData("resolver()", [])
+    }]);
+
+    // Now we'll call the Resolver's `lookup(sig)` method to get the address of the contract
+    // our tx was actually getting forwarded to.
+    contractAddress = await this.provider.send("eth_call",[
+      {
+        to: hexStripZeros(resolverAddress),
+        data: iface.encodeFunctionData("lookup(bytes4)", [signature])
+      }
+    ]);
+
+    contractAddress = hexStripZeros(contractAddress);
+
+  // Don't forget this is all a bit speculative...
+  } catch (err) {
+    this.unresolvedCalls++;
+    return;
+  }
+
+  // With the correct address, we can use the ProxyResolver class's
+  // data.getNameByAddress and/or resolveByDeployedBytecode methods
+  // (both are available in this scope, bound to `this`) to derive
+  // the target contract's name.
+  if (contractAddress && contractAddress !== "0x") {
+    contractName = await this.data.getNameByAddress(contractAddress);
+
+    // Try to resolve by deployedBytecode
+    if (contractName) return contractName;
+    else return this.resolveByDeployedBytecode(contractAddress);
+  }
+}

--- a/src/lib/resolvers/index.ts
+++ b/src/lib/resolvers/index.ts
@@ -1,9 +1,9 @@
 
-import type {GasData} from "./gasData";
+import type {GasData} from "../gasData";
 import { EthereumProvider } from "hardhat/types";
-import { GasReporterOptions, JsonRpcTx } from "../types";
+import { GasReporterOptions, JsonRpcTx } from "../../types";
 
-export class ProxyResolver {
+export class Resolver {
   public unresolvedCalls: number;
   public data: GasData;
   public provider: EthereumProvider;

--- a/src/lib/resolvers/index.ts
+++ b/src/lib/resolvers/index.ts
@@ -1,21 +1,23 @@
-
 import type {GasData} from "../gasData";
-import { EthereumProvider } from "hardhat/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { GasReporterOptions, JsonRpcTx } from "../../types";
+import { customResolver as OZResolver } from "./oz";
 
 export class Resolver {
   public unresolvedCalls: number;
   public data: GasData;
-  public provider: EthereumProvider;
+  public hre: HardhatRuntimeEnvironment;
   public resolveByProxy: Function;
 
-  constructor(options: GasReporterOptions, provider: EthereumProvider, data: GasData) {
+  constructor(hre: HardhatRuntimeEnvironment, options: GasReporterOptions, data: GasData) {
     this.unresolvedCalls = 0;
     this.data = data;
-    this.provider = provider;
+    this.hre = hre;
 
     if (typeof options.proxyResolver === "function") {
       this.resolveByProxy = options.proxyResolver.bind(this);
+    } else if (hre.__hhgrec.usingOZ) {
+      this.resolveByProxy = OZResolver.bind(this);
     } else {
       this.resolveByProxy = this.resolveByMethodSignature;
     }
@@ -45,7 +47,7 @@ export class Resolver {
   public async resolveByDeployedBytecode(address: string | null): Promise<string | null> {
     if (!address) return null;
 
-    const code = await this.provider.send("eth_getCode", [address, "latest"]);
+    const code = await this.hre.network.provider.send("eth_getCode", [address, "latest"]);
     const match = this.data.getContractByDeployedBytecode(code);
 
     if (match !== null) {

--- a/src/lib/resolvers/oz.ts
+++ b/src/lib/resolvers/oz.ts
@@ -1,0 +1,61 @@
+import { JsonRpcTx } from "../../types";
+import { Resolver } from "./index";
+
+/**
+ * Custom resolver for OpenZeppelin's upgrades and defender plugins. There are two
+ * types of upgrade for both systems, `erc1967` and `beacon`. They are queried in a
+ * series for the missing contract's implementation address. Resolver is attached
+ * when `upgrades` or `defender` are list
+ *
+ * Returns contract name matching the resolved address.
+ * @param  {Resolver}                     `this`
+ * @param  {JsonRpcTx} transaction        JSONRPC formatted transaction
+ * @return {Promise<string | null>}       contract name
+ */
+export async function customResolver(this: Resolver, transaction: JsonRpcTx): Promise<string | null> {
+  let contractAddress;
+
+  try {
+    contractAddress = await (this.hre as any).upgrades.erc1967.getImplementationAddress(transaction.to!);
+    const contractName = await matchToAddress(this, contractAddress);
+    if (contractName) return contractName;
+  } catch(err) {}
+
+  try {
+    const beaconAddress = await (this.hre as any).upgrades.erc1967.getBeaconAddress(transaction.to!);
+    contractAddress = await (this.hre as any).upgrades.beacon.getImplementationAddress(beaconAddress);
+    const contractName = await matchToAddress(this, contractAddress);
+    if (contractName) return contractName;
+  } catch(err) {}
+
+  try {
+    contractAddress = await (this.hre as any).defender.erc1967.getImplementationAddress(transaction.to!);
+    const contractName = await matchToAddress(this, contractAddress);
+    if (contractName) return contractName;
+  } catch(err) {}
+
+  try {
+    const beaconAddress = await (this.hre as any).defender.erc1967.getBeaconAddress(transaction.to!);
+    contractAddress = await (this.hre as any).defender.beacon.getImplementationAddress(beaconAddress);
+    const contractName = await matchToAddress(this, contractAddress);
+    if (contractName) return contractName;
+  } catch(err) {}
+
+  this.unresolvedCalls++;
+  return null;
+}
+
+async function matchToAddress(
+  resolver: Resolver,
+  contractAddress: string
+): Promise<string | null | undefined> {
+  if (contractAddress && contractAddress !== "0x") {
+    const contractName = await resolver.data.getNameByAddress(contractAddress);
+
+    if (contractName) return contractName;
+
+    // Try to resolve by deployedBytecode
+    return resolver.resolveByDeployedBytecode(contractAddress);
+  }
+}
+

--- a/src/tasks/gasReporter.ts
+++ b/src/tasks/gasReporter.ts
@@ -26,16 +26,18 @@ subtask(TASK_GAS_REPORTER_START).setAction(
         return result;
       }
 
-      // We need to compile so we have access to the artifact data.
+      // Need to compile so we have access to the artifact data.
       // This will rerun in TASK_TEST & TASK_RUN but should be a noop there.
       if (!args.noCompile) {
         await hre.run(TASK_COMPILE, { quiet: true });
       }
       const contracts = await getContracts(hre, options);
 
-      hre.__hhgrec.collector = new Collector(options, hre.network.provider);
-      hre.__hhgrec.collector.data.initialize(options, hre.network.provider, contracts);
       hre.__hhgrec.usingViem = (hre as any).viem !== undefined;
+      hre.__hhgrec.usingOZ  = ((hre as any).upgrades !== undefined) || ((hre as any).defender !== undefined)
+
+      hre.__hhgrec.collector = new Collector(hre, options);
+      hre.__hhgrec.collector.data.initialize(options, hre.network.provider, contracts);
 
       await initGasReporterProvider(hre.network.provider, hre.__hhgrec);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,7 @@ export interface GasReporterOptions {
 export interface GasReporterExecutionContext {
   collector?: Collector,
   task?: string,
+  usingOZ?: boolean,
   usingViem?: boolean,
   blockGasLimit?: number;
   methodsTotalGas?: number,

--- a/test/integration/options.a.ts
+++ b/test/integration/options.a.ts
@@ -63,4 +63,12 @@ describe("Options A", function () {
     const deployment = findDeployment(deployments, "EtherRouter");
     assert.isNull(deployment);
   });
+
+  it("resolves shadowed method calls with the example proxy resolver", function(){
+    const methodA = findMethod(methods, "VersionA", "setValue");
+    const methodB = findMethod(methods, "VersionB", "setValue");
+
+    assert.equal(methodA?.numberOfCalls, 1);
+    assert.equal(methodB?.numberOfCalls, 1);
+  });
 });

--- a/test/integration/oz.ts
+++ b/test/integration/oz.ts
@@ -9,7 +9,7 @@ import { Deployment, GasReporterOutput, MethodData } from "../types";
 
 import { useEnvironment, findMethod, findDeployment } from "../helpers";
 
-describe.skip("OZ Upgrades", function () {
+describe("OZ Upgrades", function () {
   let output: GasReporterOutput;
   let methods: MethodData;
   let deployments: Deployment[];
@@ -38,7 +38,7 @@ describe.skip("OZ Upgrades", function () {
 
   after(() => execSync(`rm ${outputPath}`));
 
-  it ("should record shadowed transactions made with proxied upgrade", function(){
+  it ("should record shadowed transactions made with proxied upgrade system", function(){
     const firstBoxMethod = findMethod(methods, "ProxyBox", "setBox");
     const secondBoxMethod = findMethod(methods, "ProxyBoxV2", "setBox");
 
@@ -46,7 +46,7 @@ describe.skip("OZ Upgrades", function () {
     assert.equal(secondBoxMethod?.numberOfCalls, 1);
   });
 
-  it ("should record deployments made with proxied upgrade", function(){
+  it ("should record deployments made with proxied upgrade system", function(){
     const firstBoxDeployment = findDeployment(deployments, "ProxyBox");
     const secondBoxDeployment = findDeployment(deployments, "ProxyBoxV2");
 
@@ -57,15 +57,17 @@ describe.skip("OZ Upgrades", function () {
     assert(secondBoxDeployment!.gasData.length > 0)
   });
 
-  it ("should record shadowed transactions made with beacon proxy", function(){
+  it ("should record shadowed transactions made with beacon system", function(){
     const firstBoxMethod = findMethod(methods, "BeaconBox", "setBox");
     const secondBoxMethod = findMethod(methods, "BeaconBoxV2", "setBox");
+    const thirdBoxMethod = findMethod(methods, "BeaconBoxV2", "setBeaconId");
 
     assert.equal(firstBoxMethod?.numberOfCalls, 1);
     assert.equal(secondBoxMethod?.numberOfCalls, 1);
+    assert.equal(thirdBoxMethod?.numberOfCalls, 1);
   });
 
-  it ("should record deployments made with proxied upgrade", function(){
+  it ("should record deployments made with beacon system", function(){
     const firstBoxDeployment = findDeployment(deployments, "BeaconBox");
     const secondBoxDeployment = findDeployment(deployments, "BeaconBoxV2");
 

--- a/test/projects/options/hardhat.options.a.config.ts
+++ b/test/projects/options/hardhat.options.a.config.ts
@@ -12,6 +12,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import "@nomicfoundation/hardhat-ethers";
 import { HardhatUserConfig } from "hardhat/types";
+import { customResolver } from "../../../src/lib/resolvers/etherrouter";
 
 // We load the plugin here.
 import "../../../src/index";
@@ -41,7 +42,8 @@ const config: HardhatUserConfig = {
     excludeContracts: ["EtherRouter/EtherRouter.sol"],
     showMethodSig: true,
     enabled: true,
-    darkMode: true
+    darkMode: true,
+    proxyResolver: customResolver
   }
 };
 

--- a/test/projects/oz/contracts/BeaconBox.sol
+++ b/test/projects/oz/contracts/BeaconBox.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract BeaconBox is Initializable {
+    uint public beaconId;
     string public contents;
 
     function initialize() external initializer { }

--- a/test/projects/oz/contracts/BeaconBoxV2.sol
+++ b/test/projects/oz/contracts/BeaconBoxV2.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract BeaconBoxV2 is Initializable {
+    uint public beaconId;
     string public contents;
 
     function initialize() external initializer { }
@@ -14,5 +15,9 @@ contract BeaconBoxV2 is Initializable {
 
     function setBox(string memory _contents) public {
         contents = _contents;
+    }
+
+    function setBeaconId(uint _id) public {
+        beaconId = _id;
     }
 }

--- a/test/projects/oz/contracts/ProxyBox.sol
+++ b/test/projects/oz/contracts/ProxyBox.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract ProxyBox is Initializable {
+    uint public proxyId;
     string public contents;
 
     function initialize() external initializer { }

--- a/test/projects/oz/contracts/ProxyBoxV2.sol
+++ b/test/projects/oz/contracts/ProxyBoxV2.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract ProxyBoxV2 is Initializable {
+    uint public proxyId;
     string public contents;
 
     function initialize() external initializer { }
@@ -14,5 +15,9 @@ contract ProxyBoxV2 is Initializable {
 
     function setBox(string memory _contents) public {
         contents = _contents;
+    }
+
+    function setProxyId(uint _id) public {
+        proxyId = _id;
     }
 }

--- a/test/projects/oz/test/box.ts
+++ b/test/projects/oz/test/box.ts
@@ -1,5 +1,6 @@
 import { ethers, upgrades } from "hardhat";
 
+// Tests adapted from OZ Hardhat plugin documentation examples
 describe("Box", function() {
   it('uses a method shadowed by an upgrade (Proxy)', async function() {
     const ProxyBox = await ethers.getContractFactory("ProxyBox");
@@ -17,7 +18,7 @@ describe("Box", function() {
     const BeaconBoxV2 = await ethers.getContractFactory("BeaconBoxV2");
 
     const beacon = await upgrades.deployBeacon(BeaconBox);
-    const instance = await upgrades.deployBeaconProxy(await beacon.getAddress(), BeaconBox);
+    const instance = await upgrades.deployBeaconProxy(beacon, BeaconBox);
 
     await instance.setBox('hello');
 
@@ -25,6 +26,7 @@ describe("Box", function() {
     const upgraded = BeaconBoxV2.attach(await instance.getAddress());
 
     await upgraded.setBox('hello again');
+    await upgraded.setBeaconId(5);
   });
 });
 


### PR DESCRIPTION
+ Port etherrouter example resolver from eth-gas-reporter
+ Add OZ upgrades resolver

By default, if user does not define their own proxy resolver in the options and `upgrades` or `defender` are defined on the `hre`, the reporter will try to resolve unknown txs by querying OZ for the ERC1967 underlying implementation.   