### PR TITLE
Move imports within task where possible & misc refactoring

### DIFF
--- a/src/extend.ts
+++ b/src/extend.ts
@@ -5,16 +5,11 @@ import { EIP1193Provider, HardhatConfig, HardhatUserConfig } from "hardhat/types
 import "./type-extensions";
 
 import { getDefaultOptions } from './lib/options';
-import { GasReporterProvider } from "./lib/providers";
+import { GasReporterProvider } from "./lib/provider";
 import { GasReporterExecutionContext } from "./types";
 
 let _globalGasReporterProviderReference: GasReporterProvider;
 
-/* Initialize the provider with the execution context */
-export async function initGasReporterProvider(provider: EIP1193Provider, context: GasReporterExecutionContext)  {
-  await (provider as any).init()
-  _globalGasReporterProviderReference._setGasReporterExecutionContext(context);
-}
 
 /* Config */
 extendConfig(
@@ -43,3 +38,15 @@ extendProvider(async (provider) => {
   _globalGasReporterProviderReference = newProvider;
   return newProvider;
 });
+
+/*
+   Initialize the provider with the execution context. This is called in `TASK_GAS_REPORTER_START`
+   at the very end of setup. Provider extension above should not be used on unrelated tasks.
+*/
+export async function initializeGasReporterProvider(
+  provider: EIP1193Provider,
+  context: GasReporterExecutionContext
+)  {
+  await (provider as any).init()
+  _globalGasReporterProviderReference.initializeGasReporterProvider(context);
+}

--- a/src/lib/collector.ts
+++ b/src/lib/collector.ts
@@ -42,6 +42,11 @@ export class Collector {
       await this._collectMethodsData(tx, receipt, false);
   }
 
+  /**
+   * Method called by the request monitor on the provider to gas data for `eth_call`
+   * @param {ValidatedRequestArguments}    params.args  of the call
+   * @param {number}                       estimate_gas result
+   */
   public async collectCall(args: ValidatedRequestArguments, gas: number): Promise<void> {
     const callGas = gas - getIntrinsicGas(args.params[0].data);
     const fakeTx = {
@@ -63,7 +68,7 @@ export class Collector {
 
   /**
    * Extracts and stores deployments gas usage data for a tx
-   * @param  {JsonRpcTx} transaction return value of `getTransactionByHash`
+   * @param  {JsonRpcTx}          tx       return value of `getTransactionByHash`
    * @param  {TransactionReceipt} receipt
    */
   private async _collectDeploymentsData(tx: JsonRpcTx, receipt: RpcReceiptOutput): Promise<void> {
@@ -85,7 +90,7 @@ export class Collector {
 
   /**
    * Extracts and stores methods gas usage data for a tx
-   * @param  {JsonRpcTx} transaction return value of `getTransactionByHash`
+   * @param  {JsonRpcTx}          transaction return value of `getTransactionByHash`
    * @param  {TransactionReceipt} receipt
    */
   private async _collectMethodsData(

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -1,6 +1,7 @@
 import { HardhatUserConfig } from "hardhat/types";
 import {
-  DEFAULT_ARBITRUM_HARDFORK,
+  // TODO: enable when arbitrum support added
+  // DEFAULT_ARBITRUM_HARDFORK,
   DEFAULT_GET_BLOCK_API_URL,
   DEFAULT_CURRENCY,
   DEFAULT_CURRENCY_DISPLAY_PRECISION,
@@ -10,7 +11,7 @@ import {
   TABLE_NAME_TERMINAL
 } from "../constants";
 
-import { ArbitrumHardfork, GasReporterOptions, OptimismHardfork } from "../types";
+import { /* ArbitrumHardfork,*/ GasReporterOptions, OptimismHardfork } from "../types";
 
 /**
  * Validates Optimism hardfork option
@@ -23,22 +24,23 @@ function isOptimismHardfork(hardfork: string | undefined) {
   return ["bedrock, ecotone"].includes(hardfork);
 }
 
+// TODO: Enabled when arbitrum support added
 /**
  * Validates Arbitrum hardfork option
  * @param hardfork
  * @returns
  */
-function isArbitrumHardfork(hardfork: string | undefined) {
-  if (hardfork === undefined) return false;
+// function isArbitrumHardfork(hardfork: string | undefined) {
+//  if (hardfork === undefined) return false;
 
-  return ["arbOS11"].includes(hardfork);
-}
+//  return ["arbOS11"].includes(hardfork);
+// }
 
 /**
  * Sets default reporter options
  */
 export function getDefaultOptions(userConfig: Readonly<HardhatUserConfig>): GasReporterOptions {
-  let arbitrumHardfork: ArbitrumHardfork;
+  // let arbitrumHardfork: ArbitrumHardfork;
   let optimismHardfork: OptimismHardfork;
 
   const userOptions = userConfig.gasReporter;
@@ -49,13 +51,14 @@ export function getDefaultOptions(userConfig: Readonly<HardhatUserConfig>): GasR
       optimismHardfork = DEFAULT_OPTIMISM_HARDFORK;
     }
 
-    if (userOptions.L2 === "arbitrum" && !isArbitrumHardfork(userOptions.arbitrumHardfork)) {
-      arbitrumHardfork = DEFAULT_ARBITRUM_HARDFORK;
-    }
+    // TODO: enable when arbitrum support added
+    // if (userOptions.L2 === "arbitrum" && !isArbitrumHardfork(userOptions.arbitrumHardfork)) {
+    //  arbitrumHardfork = DEFAULT_ARBITRUM_HARDFORK;
+    // }
   }
 
   return {
-    arbitrumHardfork,
+    // arbitrumHardfork,
     getBlockApi: DEFAULT_GET_BLOCK_API_URL,
     currency: DEFAULT_CURRENCY,
     currencyDisplayPrecision: DEFAULT_CURRENCY_DISPLAY_PRECISION,

--- a/src/tasks/builtins.ts
+++ b/src/tasks/builtins.ts
@@ -1,6 +1,6 @@
 import {
   TASK_TEST,
-  TASK_RUN
+  // TASK_RUN
 } from "hardhat/builtin-tasks/task-names";
 
 import { task } from "hardhat/config";
@@ -25,11 +25,11 @@ task(TASK_TEST).setAction(
 /**
  * Overrides Hardhat built-in task TASK_RUN to report gas usage
  */
-task(TASK_RUN).setAction(
+/* task(TASK_RUN).setAction(
   async (args: any, hre, runSuper) => {
     hre.__hhgrec.task = TASK_RUN;
     await hre.run(TASK_GAS_REPORTER_START, args);
     await runSuper(args);
     await hre.run(TASK_GAS_REPORTER_STOP, args);
   }
-);
+);*/

--- a/src/tasks/gasReporter.ts
+++ b/src/tasks/gasReporter.ts
@@ -1,15 +1,9 @@
 import { subtask } from "hardhat/config";
 import { TASK_COMPILE } from "hardhat/builtin-tasks/task-names";
-
 import { TASK_GAS_REPORTER_START, TASK_GAS_REPORTER_STOP } from "../constants";
 
-import { getContracts } from "../lib/artifacts";
-import { setGasAndPriceRates } from "../utils/prices";
-import { initGasReporterProvider} from "../extend";
-
-import { Collector } from "../lib/collector";
-import { render } from "../lib/render"
-import { warnParallel } from "../utils/ui";
+// This has to be a top level import
+import { initializeGasReporterProvider} from "../extend";
 
 /**
  * Initializes gas tracking
@@ -19,6 +13,11 @@ subtask(TASK_GAS_REPORTER_START).setAction(
     const options = hre.config.gasReporter;
 
     if (options.enabled === true) {
+      // Lazy load all imports to minimize HH startup time
+      const { getContracts } = await import("../lib/artifacts");
+      const { Collector } = await import("../lib/collector");
+      const { warnParallel } = await import("../utils/ui");
+
       // Temporarily skipping when in parallel mode because it crashes and unsure how to resolve...
       if (args.parallel === true) {
         const result = await runSuper();
@@ -31,22 +30,23 @@ subtask(TASK_GAS_REPORTER_START).setAction(
       if (!args.noCompile) {
         await hre.run(TASK_COMPILE, { quiet: true });
       }
+
       const contracts = await getContracts(hre, options);
 
       hre.__hhgrec.usingCall = options.reportPureAndViewMethods;
-      hre.__hhgrec.usingViem = (hre as any).viem !== undefined;
-      hre.__hhgrec.usingOZ  = ((hre as any).upgrades !== undefined) || ((hre as any).defender !== undefined)
+      hre.__hhgrec.usingViem = (hre as any).viem;
+      hre.__hhgrec.usingOZ  = (hre as any).upgrades || (hre as any).defender
 
       hre.__hhgrec.collector = new Collector(hre, options);
-      hre.__hhgrec.collector.data.initialize(options, hre.network.provider, contracts);
+      hre.__hhgrec.collector.data.initialize(hre.network.provider, contracts);
 
       // Custom proxy resolvers are instantiated in the config,
       // OZ proxy resolver instantiated in Resolver constructor called by new Collector()
-      hre.__hhgrec.methodIgnoreList = (options.proxyResolver !== undefined)
+      hre.__hhgrec.methodIgnoreList = (options.proxyResolver)
         ? options.proxyResolver.ignore()
         : [];
 
-      await initGasReporterProvider(hre.network.provider, hre.__hhgrec);
+      await initializeGasReporterProvider(hre.network.provider, hre.__hhgrec);
     }
   }
 );
@@ -59,6 +59,9 @@ subtask(TASK_GAS_REPORTER_STOP).setAction(
     const options = hre.config.gasReporter;
 
     if (options.enabled === true && args.parallel !== true) {
+      const { setGasAndPriceRates } = await import("../utils/prices");
+      const { render } = await import("../lib/render");
+
       const warnings = await setGasAndPriceRates(options);
 
       await hre.__hhgrec.collector?.data.runAnalysis(hre, options);

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,8 +68,9 @@ export interface GasReporterOptions {
   /** @property Include standard 21_000 + calldata bytes fees in method gas usage data */
   includeIntrinsicGas?: boolean;
 
+  // TODO: Enable arbitrum when support added
   /** @property L2 Network to calculate execution costs for */
-  L2?: "optimism" | "arbitrum"
+  L2?: "optimism" // | "arbitrum"
 
   /** @property Omit terminal color in output */
   noColors?: boolean;

--- a/test/integration/options.default.ts
+++ b/test/integration/options.default.ts
@@ -13,7 +13,7 @@ import {
   TABLE_NAME_TERMINAL
 } from "../../src/constants";
 
-import { Deployment, GasReporterOptions, GasReporterOutput, MethodData } from "../types";
+import { Deployment, GasReporterOptions, GasReporterOutput, MethodData } from "../../src/types";
 import { useEnvironment, findMethod, findDeployment } from "../helpers";
 
 describe("Default Options", function () {


### PR DESCRIPTION
#170 

+ Imports should be lazy loaded at the entry points if possible to minimize startup times for everything else.
+ Disable or comment out arbitrum stubs 
  + (Deferred via #181 )
+ Comment out TASK_RUN stubs
  + (Deferred via #195 ) 