### PR TITLE
Fix crash when --parallel flag is used

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ task(TASK_TEST).setAction(
  * Initializes gas tracking
  */
 subtask(TASK_GAS_REPORTER_START).setAction(
-  async (args: any, hre, runSuper) => {
+  async (args: any, hre) => {
     const options = hre.config.gasReporter;
 
     if (options.enabled === true) {
@@ -108,15 +108,14 @@ subtask(TASK_GAS_REPORTER_START).setAction(
       // Temporarily skipping when in parallel mode because it crashes and
       // unsure how to resolve...
       if (args.parallel === true) {
-        const result: any = await runSuper();
         warnParallel();
-        return result;
+        return;
       }
 
       // solidity-coverage disables gas reporter via mocha but that
       // no longer works for this version. (No warning necessary)
       if ((hre as any).__SOLIDITY_COVERAGE_RUNNING === true) {
-        return runSuper();
+        return;
       }
 
       // Need to compile so we have access to the artifact data.

--- a/test/integration/parallel.ts
+++ b/test/integration/parallel.ts
@@ -1,0 +1,22 @@
+import { TASK_TEST } from "hardhat/builtin-tasks/task-names";
+import path from "path";
+
+import { useEnvironment } from "../helpers";
+
+describe("--parallel", function () {
+  const projectPath = path.resolve(
+    __dirname,
+    "../projects/viem"
+  );
+
+  const network = undefined;
+  const configPath = "./hardhat.config.ts";
+
+  useEnvironment(projectPath, network, configPath);
+
+  before(async function(){
+    await this.env.run(TASK_TEST, { parallel: true, testFiles: [] });
+  })
+
+  it ("should complete successfully", function(){});
+});


### PR DESCRIPTION
#218 

This logic used to be inside TASK_TEST, so it needed to `runSuper()`. An error is thrown if there's no override. 

Simply returning could be an issue for anyone who wants to override the reporter tasks. 

Warning is displayed correctly now:
```
>>>>> WARNING (hardhat-gas-reporter plugin) <<<<<<
Gas reporting has been skipped because plugin `hardhat-gas-reporter` does not support the --parallel flag.
>>>>>>>>>>>>>>>>>>>>
```

 