### PR TITLE
Collect intrinsicGas for JSON output

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -255,8 +255,9 @@ interface MethodDataItem {
   contract: string,  // Contract name
   method: string,    // Method name
   fnSig: string,     // Full method call signature
-  callData: number[],
-  gasData: number[],
+  callData: number[],           // L1 gas used for calldata when emulating L2
+  gasData: number[],            // L1 or L2 evm "execution" gas
+  intrinsicGas: number[],       // Intrinsic gas associated with each gasData entry
   numberOfCalls: number,
   min?: number,
   max?: number,

--- a/src/lib/collector.ts
+++ b/src/lib/collector.ts
@@ -129,8 +129,11 @@ export class Collector {
         ? 0
         : getCalldataGasForNetwork(this.options, tx as JsonRpcTx);
 
+      const intrinsicGas = getIntrinsicGas(tx.input);
+
       this.data.methods[id].gasData.push(executionGas);
       this.data.methods[id].callData.push(calldataGas);
+      this.data.methods[id].intrinsicGas.push(intrinsicGas);
       this.data.methods[id].numberOfCalls += 1;
       this.data.methods[id].isCall = this.data.methods[id].isCall || !this.options.includeIntrinsicGas;
     } else {

--- a/src/lib/gasData.ts
+++ b/src/lib/gasData.ts
@@ -96,6 +96,7 @@ export class GasData {
             contract: contract.name,
             method: methodIDs[key].name,
             fnSig: methodIDs[key].fnSig,
+            intrinsicGas: [],
             callData: [],
             gasData: [],
             numberOfCalls: 0

--- a/src/types.ts
+++ b/src/types.ts
@@ -205,6 +205,7 @@ export interface MethodDataItem {
   fnSig: string,
   callData: number[],
   gasData: number[],
+  intrinsicGas: number[],
   numberOfCalls: number,
   min?: number,
   max?: number,

--- a/test/integration/options.default.ts
+++ b/test/integration/options.default.ts
@@ -108,12 +108,15 @@ describe("Default Options", function () {
     const dataItem = findMethod(methods, "VariableCosts", "addToMap");
     assert.equal(dataItem?.numberOfCalls, 4);
     assert.equal(dataItem?.gasData.length, 4);
+    assert.equal(dataItem?.intrinsicGas.length, 4);
     assert.exists(dataItem?.min);
     assert.exists(dataItem?.max);
     assert.exists(dataItem?.executionGasAverage);
     assert(dataItem!.min! < dataItem!.max!);
     assert(dataItem!.min! < dataItem!.executionGasAverage!);
-    assert(dataItem!.executionGasAverage! < dataItem!.max!)
+    assert(dataItem!.executionGasAverage! < dataItem!.max!);
+    assert(dataItem?.intrinsicGas[0]! > 21_000);
+    assert(dataItem?.gasData[0]! > dataItem?.intrinsicGas[0]!);
   });
 
   it("should collect deployment data for contracts with names that shadow each other", function(){


### PR DESCRIPTION
Adds `intrinsicGas` array to JSON output for each MethodDataItem entry. 

Lets post-processors fine-tune what methods include intrinsic gas in their measurements or isolate the execution gas component for comparative analysis more easily. 