### PR TITLE
Fix bug when `blobBaseFee` is sub-gwei

### DIFF
--- a/src/lib/render/markdown.ts
+++ b/src/lib/render/markdown.ts
@@ -74,7 +74,7 @@ export function generateMarkdownTable(
             ]
           : [
               [`L1 Base Fee`, `${options.baseFee!} gwei`],
-              [`L1 Blob Base Fee`, `${l1GweiBlobBaseFee} gwei`],
+              [`L1 Blob Base Fee`, `${l1GweiBlobBaseFee!} gwei`],
               [`L2 Gas Price`, `${l2gwei} gwei` ]
             ]
 

--- a/src/lib/render/markdown.ts
+++ b/src/lib/render/markdown.ts
@@ -51,6 +51,7 @@ export function generateMarkdownTable(
   let gasPrices: string[][];
   let l1gwei: string | number | undefined;
   let l2gwei: string | number | undefined;
+  let l1GweiBlobBaseFee: string | number | undefined;
   const { network, currency, nonZeroMsg, intrinsicMsg } = getCommonTableVals(options);
   let tokenPrice = "-";
   let rate: string;
@@ -60,6 +61,7 @@ export function generateMarkdownTable(
     ({
       l1gwei,
       l2gwei,
+      l1GweiBlobBaseFee,
       rate,
       token
     } = getCommonTableVals(options));
@@ -72,7 +74,7 @@ export function generateMarkdownTable(
             ]
           : [
               [`L1 Base Fee`, `${options.baseFee!} gwei`],
-              [`L1 Blob Base Fee`, `${options.blobBaseFee!} gwei`],
+              [`L1 Blob Base Fee`, `${l1GweiBlobBaseFee} gwei`],
               [`L2 Gas Price`, `${l2gwei} gwei` ]
             ]
 

--- a/src/lib/render/terminal.ts
+++ b/src/lib/render/terminal.ts
@@ -328,7 +328,7 @@ export function generateTerminalTextTable(
       opStackConfig.push({
         hAlign: "left",
         colSpan: 2,
-        content: chalk.cyan(`L1: ${l1GweiBlobBaseFee} gwei (blobBaseFee)`)
+        content: chalk.cyan(`L1: ${l1GweiBlobBaseFee!} gwei (blobBaseFee)`)
       });
       opStackConfig.push({
         hAlign: "left",

--- a/src/lib/render/terminal.ts
+++ b/src/lib/render/terminal.ts
@@ -288,6 +288,7 @@ export function generateTerminalTextTable(
       l2gwei,
       l1gweiNote,
       l2gweiNote,
+      l1GweiBlobBaseFee,
       network,
       rate,
       currency,
@@ -327,7 +328,7 @@ export function generateTerminalTextTable(
       opStackConfig.push({
         hAlign: "left",
         colSpan: 2,
-        content: chalk.cyan(`L1: ${options.blobBaseFee!} gwei (blobBaseFee)`)
+        content: chalk.cyan(`L1: ${l1GweiBlobBaseFee} gwei (blobBaseFee)`)
       });
       opStackConfig.push({
         hAlign: "left",

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -129,9 +129,10 @@ export async function setGasAndPriceRates(options: GasReporterOptions): Promise<
     !options.blobBaseFee
   ) {
     try {
-      const blobBaseFee = await axiosInstance.get(blobBaseFeeUrl);
-      checkForEtherscanError(blobBaseFee.data.result);
-      options.blobBaseFee = Math.round(hexWeiToIntGwei(blobBaseFee.data.result))
+      const response = await axiosInstance.get(blobBaseFeeUrl);
+      checkForEtherscanError(response.data.result);
+      const blobBaseFee = hexWeiToIntGwei(response.data.result);
+      options.blobBaseFee = (blobBaseFee >= 1 ) ? Math.round(blobBaseFee) : blobBaseFee;
     } catch (error) {
       options.blobBaseFee = DEFAULT_BLOB_BASE_FEE;
       warnings.push(warnBlobBaseFeeRemoteCallFailed(error));

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -211,6 +211,7 @@ export function getCommonTableVals(options: GasReporterOptions) {
 
   let l2BaseFeeNote = "(baseFee)";
   let l1GweiForL2 = options.baseFee;
+  let l1GweiBlobBaseFee: string | number | undefined = options.blobBaseFee;
 
   if (options.L2 === "arbitrum"){
     l2BaseFeeNote = "(baseFeePerByte)"
@@ -245,6 +246,12 @@ export function getCommonTableVals(options: GasReporterOptions) {
     l2gwei = parseFloat(l2gwei.toString()).toFixed(DEFAULT_GAS_PRICE_PRECISION);
   }
 
+  if (typeof l1GweiBlobBaseFee === "number" && l1GweiBlobBaseFee < 1) {
+    l1GweiBlobBaseFee = parseFloat(l1GweiBlobBaseFee.toString()).toFixed(DEFAULT_GAS_PRICE_PRECISION);
+  }
+
+
+
   const nonZeroMsg = "Cost was non-zero but below the precision setting for the currency display (see options)";
   const intrinsicMsg = "Execution gas for this method does not include intrinsic gas overhead ";
 
@@ -253,6 +260,7 @@ export function getCommonTableVals(options: GasReporterOptions) {
     l2gwei,
     l1gweiNote,
     l2gweiNote,
+    l1GweiBlobBaseFee,
     network,
     rate,
     currency,

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -250,8 +250,6 @@ export function getCommonTableVals(options: GasReporterOptions) {
     l1GweiBlobBaseFee = parseFloat(l1GweiBlobBaseFee.toString()).toFixed(DEFAULT_GAS_PRICE_PRECISION);
   }
 
-
-
   const nonZeroMsg = "Cost was non-zero but below the precision setting for the currency display (see options)";
   const intrinsicMsg = "Execution gas for this method does not include intrinsic gas overhead ";
 

--- a/test/integration/options.e.ts
+++ b/test/integration/options.e.ts
@@ -54,7 +54,7 @@ describe("Options E (OPStack:optimism with live pricing & `reportPureAndViewMeth
     assert.isDefined(options.gasPrice);
     assert.isDefined(options.blobBaseFee);
     assert.isBelow(options.gasPrice!, 1);
-    assert.isAbove(options.blobBaseFee!, 1);
+    assert.isAbove(options.blobBaseFee!, 0);
 
     assert.isDefined(options.tokenPrice);
     assert.isAbove(parseFloat(options.tokenPrice!), 1000); // Eth-ish

--- a/test/integration/options.f.ts
+++ b/test/integration/options.f.ts
@@ -54,7 +54,7 @@ describe("Options F (OPStack:base with live pricing & `reportPureAndViewMethods`
     assert.isDefined(options.gasPrice);
     assert.isDefined(options.blobBaseFee);
     assert.isBelow(options.gasPrice!, 1);
-    assert.isAbove(options.blobBaseFee!, 1);
+    assert.isAbove(options.blobBaseFee!, 0);
 
     assert.isDefined(options.tokenPrice);
     assert.isAbove(parseFloat(options.tokenPrice!), 1000); // Eth-ish

--- a/test/integration/options.g.ts
+++ b/test/integration/options.g.ts
@@ -53,7 +53,7 @@ describe("Options G (Arbitrum with live pricing & `reportPureAndViewMethods`)", 
     assert.isDefined(options.gasPrice);
     assert.isDefined(options.baseFeePerByte);
     assert.isBelow(options.gasPrice!, 1);
-    assert.isAbove(options.baseFeePerByte!, 1);
+    assert.isAbove(options.baseFeePerByte!, 0);
 
     assert.isDefined(options.tokenPrice);
     assert.isAbove(parseFloat(options.tokenPrice!), 1000); // Eth-ish

--- a/test/projects/options/hardhat.options.g.config.ts
+++ b/test/projects/options/hardhat.options.g.config.ts
@@ -19,6 +19,7 @@ const config: HardhatUserConfig = {
   },
   gasReporter: {
     coinmarketcap: process.env.CMC_API_KEY,
+    currencyDisplayPrecision: 4,
     L2: "arbitrum",
     L1Etherscan: process.env.ETHERSCAN_API_KEY,
     L2Etherscan: process.env.ARBITRUM_API_KEY,


### PR DESCRIPTION
Not sure what's going on ... it seems like there aren't reliable blobBaseFee sources. The OP stack GasOracle contracts have reverted to pricing it at 1 wei.

It bounced around btw 20 and 40 gwei all week.