### PR TITLE
Update solidity-parser/parser to 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/units": "^5.7.0",
-    "@solidity-parser/parser": "^0.18.0",
+    "@solidity-parser/parser": "^0.19.0",
     "axios": "^1.6.7",
     "brotli-wasm": "^2.0.1",
     "chalk": "4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,9 +1041,10 @@
   dependencies:
     tslib "^2.5.0"
 
-"@solidity-parser/parser@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.18.0.tgz#8e77a02a09ecce957255a2f48c9a7178ec191908"
+"@solidity-parser/parser@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.19.0.tgz#37a8983b2725af9b14ff8c4a475fa0e98d773c3f"
+  integrity sha512-RV16k/qIxW/wWc+mLzV3ARyKUaMUTBy9tOLMzFhtNSKYeTAanQ3a5MudJKf/8arIFnA2L27SNjarQKmFg0w/jA==
 
 "@types/bn.js@^4.11.3":
   version "4.11.6"


### PR DESCRIPTION
Latest version supports solc `0.8.28` transient variables:

https://github.com/solidity-parser/parser/releases/tag/v0.19.0