### PR TITLE
fix: typos in unit test descriptions

### DIFF
--- a/test/projects/options/test/wallet.ts
+++ b/test/projects/options/test/wallet.ts
@@ -13,7 +13,7 @@ describe("Wallet", function() {
     walletB = await Wallet.deploy();
   });
 
-  it("should should allow transfers and sends", async () => {
+  it("should allow transfers and sends", async () => {
     await walletA.fallback!({ value: 100 });
     await walletA.sendPayment(50, await walletB.getAddress());
     await walletA.transferPayment(50, await walletB.getAddress());

--- a/test/unit/gas.ts
+++ b/test/unit/gas.ts
@@ -67,7 +67,7 @@ describe("Optimism: getCalldataCostForNetwork", function () {
     opStackBlobBaseFeeScalar: OPTIMISM_ECOTONE_BLOB_BASE_FEE_SCALAR
   }
 
-  it("calculates gas cost for small function call tx (bedrock", function () {
+  it("calculates gas cost for small function call tx (bedrock)", function () {
     const fn = optimismCases.bedrockFunction_1;
     options.gasPrice = fn.l2GasPrice;
     options.baseFee = fn.l1BaseFee;


### PR DESCRIPTION
Corrected `it("should should allow` to `it("should allow`
Corrected `(bedrock"` to `(bedrock)"`