### PR TITLE
Revert "Update solidity-parser/parser to 0.20.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/units": "^5.7.0",
-    "@solidity-parser/parser": "^0.20.0",
+    "@solidity-parser/parser": "^0.19.0",
     "axios": "^1.6.7",
     "brotli-wasm": "^2.0.1",
     "chalk": "4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,10 +991,10 @@
   dependencies:
     tslib "^2.5.0"
 
-"@solidity-parser/parser@^0.20.0":
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.20.0.tgz#e221b2f29a8c2fbeab56fea6d135e28b569b9ba9"
-  integrity sha512-eYOX1xI9ssc3AIZtKPdE2chG1OT9S74O16b8GhWGab63NS5g4jyQgW5OiwUiX9ACL0FR24rVDaHo+BB0bRSHhQ==
+"@solidity-parser/parser@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.19.0.tgz#37a8983b2725af9b14ff8c4a475fa0e98d773c3f"
+  integrity sha512-RV16k/qIxW/wWc+mLzV3ARyKUaMUTBy9tOLMzFhtNSKYeTAanQ3a5MudJKf/8arIFnA2L27SNjarQKmFg0w/jA==
 
 "@types/bn.js@^4.11.3":
   version "4.11.6"


### PR DESCRIPTION
Reverts cgewecke/hardhat-gas-reporter#266

There's an issue with how strict treatment of `at` and `layout` keyword treatment is which could affect OZ. 

cf: https://github.com/solidity-parser/parser/issues/123