### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'yarn'
@@ -32,8 +32,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'yarn'
@@ -43,8 +43,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'yarn'


### PR DESCRIPTION
Changes
Updates actions/checkout from v3 to v4
Updates actions/setup-node from v3 to v4 

References
actions/checkout@v4: https://github.com/actions/checkout/releases/tag/v4.2.2
actions/setup-node@v4:https://github.com/actions/setup-node/releases/tag/v4.4.0
These updates ensure we're using the latest stable versions of GitHub Actions, bringing improved security and performance benefits.