### PR TITLE
Fix: Handle null transactions in OpenZeppelin proxy deployments

### DIFF
--- a/src/lib/collector.ts
+++ b/src/lib/collector.ts
@@ -71,7 +71,7 @@ export class Collector {
    * @param  {TransactionReceipt} receipt
    */
   private async _collectDeploymentsData(tx: JsonRpcTx, receipt: RpcReceiptOutput): Promise<void> {
-    const match = this.data.getContractByDeploymentInput(tx.input!);
+    const match = tx?.input ? this.data.getContractByDeploymentInput(tx.input) : null;
 
     if (match !== null) {
       await this.data.trackNameByAddress(


### PR DESCRIPTION
**Problem**

hardhat-gas-reporter crashes with `TypeError: Cannot read properties of null (reading 'input')` when running tests that deploy OpenZeppelin proxies with constructor arguments (e.g., `upgrades.deployProxy(Contract, [arg1, arg2])`).

**Root Cause**

During OpenZeppelin proxy deployment with initialization arguments, the upgrades plugin creates internal validation transactions. Some of these validation transactions are null, but the gas reporter's `_collectDeploymentsData()` method assumes all transactions have an input property, causing crashes at line 74.

**Solution**

Add null safety check to line 74 in src/lib/collector.ts:

```
// Before (crashes on null transactions):
const match = this.data.getContractByDeploymentInput(tx.input!);

// After (handles null transactions gracefully):
const match = tx?.input ? this.data.getContractByDeploymentInput(tx.input) : null;
```

The fix ensures that when tx is null (which happens during OpenZeppelin's internal validation transactions), we gracefully return null for the match instead of crashing when trying to access tx.input.

**Impact**

- Fixes compatibility with OpenZeppelin proxy deployments that have constructor arguments
- Maintains existing functionality for all other transaction types
- No breaking changes to existing users

**Testing**

Verified fix resolves issues with:
- Various proxy deployments with constructor arguments
- Complex OpenZeppelin upgrade patterns
- Mixed test suites with both simple and complex proxy deployments

This is a minimal, targeted fix that handles the edge case of null transactions during OpenZeppelin's internal validation process without affecting normal gas reporting functionality.